### PR TITLE
Introduce model `FindBy` trait

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,8 @@ jobs:
         php-version: ['8.2', '8.3', '8.4']
         laravel-version: [11, 12]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        stability: [prefer-lowest, prefer-stable]
-        experimental: [false]
 
     runs-on: ${{ matrix.os }}
-
-    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout code
@@ -55,13 +51,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-${{ matrix.stability }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-${{ matrix.stability }}-composer-
+          key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-
 
       - name: Install dependencies
         run: |
           composer require laravel/framework:${{ matrix.laravel-version }}.* --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --prefer-dist --no-interaction
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /vendor/
-/build/
 .env
 /.phpunit.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "jasonmccreary/laravel-additions",
     "type": "library",
     "description": "WIP",
-    "keywords": ["laravel"],
+    "keywords": [
+        "laravel"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.2",
@@ -34,12 +36,36 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Tests\\": "tests/",
+            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
         },
         "exclude-from-classmap": [
             "tests/fixtures/"
         ]
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare"
+        ],
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@build",
+            "@php vendor/bin/testbench serve --ansi"
+        ],
+        "lint": [
+            "@php vendor/bin/pint --ansi"
+        ],
+        "test": [
+            "@clear",
+            "@php vendor/bin/phpunit"
+        ]
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage/>
-  <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
-    </testsuite>
-    <testsuite name="Feature">
-      <directory suffix="Test.php">./tests/Feature</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" backupGlobals="false"
+         bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false"
+         cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+    <coverage/>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+    <php>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>

--- a/src/Traits/FindBy.php
+++ b/src/Traits/FindBy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Traits;
+
+trait FindBy
+{
+    public static function __callStatic($method, $arguments)
+    {
+        if (! str_starts_with(strtolower($method), 'findby')) {
+            return parent::__callStatic($method, $arguments);
+        }
+
+        $column = str($method)->substr(6)->snake()->value();
+
+        $query = static::query();
+
+        if (isset($arguments[1])) {
+            $query = $query->select($arguments[1]);
+        }
+
+        if (is_array($arguments[0])) {
+            $query = $query->whereIn($column, $arguments[0])->get();
+        } else {
+            $query = $query->where($column, $arguments[0])->first();
+        }
+
+        return $query;
+    }
+}

--- a/src/Traits/FindBy.php
+++ b/src/Traits/FindBy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Traits;
+namespace JMac\Additions\Traits;
 
 trait FindBy
 {

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,32 @@
+laravel: '@testbench'
+
+providers:
+  # - Workbench\App\Providers\WorkbenchServiceProvider
+
+migrations:
+  - workbench/database/migrations
+
+seeders:
+  - Workbench\Database\Seeders\DatabaseSeeder
+
+workbench:
+  start: '/'
+  install: true
+  health: false
+  discovers:
+    web: true
+    api: false
+    commands: false
+    components: false
+    views: false
+  build:
+    - asset-publish
+    - create-sqlite-db
+    - db-wipe
+    - migrate-fresh
+  assets:
+    - laravel-assets
+  sync:
+    - from: storage
+      to: workbench/storage
+      reverse: true

--- a/tests/Feature/Traits/FindByTest.php
+++ b/tests/Feature/Traits/FindByTest.php
@@ -76,4 +76,19 @@ final class FindByTest extends TestCase
         $this->assertSame(['title' => 'Title 1'], $result->first()->toArray());
         $this->assertSame(['title' => 'Title 2'], $result->last()->toArray());
     }
+
+    #[Test]
+    public function it_returns_null_when_column_does_not_exist(): void
+    {
+        $this->assertNull(Post::findByUnknownColumn('uh oh'));
+    }
+
+    #[Test]
+    public function it_returns_empty_collect_when_column_does_not_exist(): void
+    {
+        $result = Post::findByUnknownColumn(['no', 'nope']);
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
 }

--- a/tests/Feature/Traits/FindByTest.php
+++ b/tests/Feature/Traits/FindByTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Workbench\App\Models\Post;
+
+final class FindByTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_returns_null_when_nothing_is_found(): void
+    {
+        $this->assertNull(Post::findByTitle('does not exist'));
+    }
+
+    #[Test]
+    public function it_returns_empty_collect_when_nothing_is_found_for_set(): void
+    {
+        $result = Post::findByTitle(['not found', 'also not found']);
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
+    #[Test]
+    public function it_returns_a_single_model_when_found(): void
+    {
+        $post = Post::factory()->create(['title' => 'My Post']);
+
+        $result = Post::findByTitle('My Post');
+
+        $this->assertInstanceOf(Post::class, $result);
+        $this->assertTrue($result->is($post));
+    }
+
+    #[Test]
+    public function it_returns_a_collection_when_found(): void
+    {
+        $post1 = Post::factory()->create(['title' => 'Title 1']);
+        $post2 = Post::factory()->create(['title' => 'Title 2']);
+
+        $result = Post::findByTitle(['Title 1', 'Title 2']);
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->first()->is($post1));
+        $this->assertTrue($result->last()->is($post2));
+    }
+
+    #[Test]
+    public function it_returns_selected_column(): void
+    {
+        $post = Post::factory()->create(['title' => 'My Post']);
+
+        $result = Post::findByTitle('My Post', ['id']);
+
+        $this->assertInstanceOf(Post::class, $result);
+        $this->assertTrue($result->is($post));
+        $this->assertSame(['id' => $post->id], $result->toArray());
+    }
+
+    #[Test]
+    public function it_returns_collection_of_selected_column(): void
+    {
+        Post::factory()->create(['title' => 'Title 1']);
+        Post::factory()->create(['title' => 'Title 2']);
+
+        $result = Post::findByTitle(['Title 1', 'Title 2'], 'title');
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertCount(2, $result);
+        $this->assertSame(['title' => 'Title 1'], $result->first()->toArray());
+        $this->assertSame(['title' => 'Title 2'], $result->last()->toArray());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,12 @@
 namespace Tests;
 
 use JMac\Additions\AdditionsServiceProvider;
+use Orchestra\Testbench\Concerns\WithWorkbench;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
+    use WithWorkbench;
+
     protected function getPackageProviders($app)
     {
         return [

--- a/tests/Unit/Support/HttpStatusTest.php
+++ b/tests/Unit/Support/HttpStatusTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Unit\Support;
 
 use JMac\Additions\Support\HttpStatus;
-use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 final class HttpStatusTest extends TestCase
 {

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use JMac\Additions\Traits\FindBy;
+use Workbench\Database\Factories\PostFactory;
+
+#[UseFactory(PostFactory::class)]
+class Post extends Model
+{
+    use FindBy, HasFactory;
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Workbench\App\Models;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Workbench\App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class WorkbenchServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/workbench/bootstrap/app.php
+++ b/workbench/bootstrap/app.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+use function Orchestra\Testbench\default_skeleton_path;
+
+return Application::configure(basePath: $APP_BASE_PATH ?? default_skeleton_path())
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        commands: __DIR__.'/../routes/console.php',
+    )
+    ->withMiddleware(function (Middleware $middleware) {
+        //
+    })
+    ->withExceptions(function (Exceptions $exceptions) {
+        //
+    })->create();

--- a/workbench/database/factories/PostFactory.php
+++ b/workbench/database/factories/PostFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Workbench\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Post;
+
+/**
+ * @template TModel of \Workbench\App\Post
+ *
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
+ */
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/workbench/database/factories/UserFactory.php
+++ b/workbench/database/factories/UserFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Workbench\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Workbench\App\Models\User;
+
+/**
+ * @template TModel of \Workbench\App\Models\User
+ *
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
+ */
+class UserFactory extends Factory
+{
+    /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    /**
+     * Indicate that the model's email address should be unverified.
+     */
+    public function unverified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'email_verified_at' => null,
+        ]);
+    }
+}

--- a/workbench/database/migrations/2025_03_20_202929_create_posts_table.php
+++ b/workbench/database/migrations/2025_03_20_202929_create_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/workbench/database/seeders/DatabaseSeeder.php
+++ b/workbench/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Workbench\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Workbench\Database\Factories\UserFactory;
+
+class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     */
+    public function run(): void
+    {
+        // UserFactory::new()->times(10)->create();
+
+        UserFactory::new()->create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+    }
+}

--- a/workbench/routes/console.php
+++ b/workbench/routes/console.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+
+// Artisan::command('inspire', function () {
+//     $this->comment(Inspiring::quote());
+// })->purpose('Display an inspiring quote');

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});


### PR DESCRIPTION
This introduces a `FindBy` trait which may be added to Eloquent models to allow calling dynamic `findBy*` methods for the underlying model column names.

It is inspired by the [dynamic finders](https://guides.rubyonrails.org/active_record_querying.html#dynamic-finders) in Rails and behaves similar to the existing `find` method in Eloquent its parameters and return values.

**Examples**
```php
Post::findByTitle('Laravel Forever');
Post::findByAuthorId([1, 3, 5]);
Post::findByAuthorId(5, ['title']);
```