### PR TITLE
Introduce `SafeSave` Eloquent trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,21 @@ Post::findByAuthorId([1, 3, 5]);
 Post::findByAuthorId(5, ['title']);
 ```
 
-To use these dynamic `findBy*` methods, simply add the `FindBy` trait to your model class.
+### `SafeSave` for models
+This package includes a `SafeSave` trait (attempted in [#50190](https://github.com/laravel/framework/pull/50190)) which may be added to your Eloquent models to save data directly from "safe" input without doing the fillable/guarded dance. More technically, you may pass the Eloquent `create` or `update` methods `ValidatedInput` without triggering a `MassAssignment` exception, regardless of the values set in the model `$fillable` or `$guarded` properties.
+
+`ValidatedInput` objects are readily available from calling the `safe` method on a `FormRequest`. This data has been validated, and, as such, is ready to save to the database.
+
+```php
+public function store(UserCreateRequest $request)
+{
+     $user = User::create($request->safe());
+
+     return redirect('user.show', $user);
+}
+```
+
+While this is the intended use case, you may, of course, create your own `ValidatedInput` object directly. To use this behavior, simply add the `SafeSave` trait to your model class.
 
 ```php
 <?php
@@ -64,11 +78,11 @@ To use these dynamic `findBy*` methods, simply add the `FindBy` trait to your mo
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use JMac\Additions\Traits\FindBy;
+use JMac\Additions\Traits\SafeSave;
 
 class Post extends Model
 {
-    use FindBy;
+    use SafeSave;
     
     // ...
 }
@@ -78,8 +92,9 @@ class Post extends Model
 ## TODO
 - [x] ~~`status` helper~~
 - [x] ~~`findBy*` for models~~
+- [x] ~~"safe objects" for models~~
 - [ ] `fallback` for policies
-- [ ] "force create" for models
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Post::findByAuthorId([1, 3, 5]);
 Post::findByAuthorId(5, ['title']);
 ```
 
+To use these dynamic `findBy*` methods, simply add the `FindBy` trait to your model class.
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use JMac\Additions\Traits\FindBy;
+
+class Post extends Model
+{
+    use FindBy;
+    
+    // ...
+}
+```
+
+---
+
 ### `SafeSave` for models
 This package includes a `SafeSave` trait (attempted in [#50190](https://github.com/laravel/framework/pull/50190)) which may be added to your Eloquent models to save data directly from "safe" input without doing the fillable/guarded dance. More technically, you may pass the Eloquent `create` or `update` methods `ValidatedInput` without triggering a `MassAssignment` exception, regardless of the values set in the model `$fillable` or `$guarded` properties.
 

--- a/src/Traits/SafeSave.php
+++ b/src/Traits/SafeSave.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace JMac\Additions\Traits;
+
+use Illuminate\Support\ValidatedInput;
+
+trait SafeSave
+{
+    public static function create(array|ValidatedInput $attributes)
+    {
+        $instance = new static;
+
+        if (is_array($attributes)) {
+            return $instance->newQuery()->create($attributes);
+        }
+
+        $instance->forceFill($attributes->all())->save();
+
+        return $instance;
+    }
+
+    public function update(array|ValidatedInput $attributes = [], array $options = [])
+    {
+        if ($attributes instanceof ValidatedInput) {
+            $this->forceFill($attributes->all());
+            $attributes = [];
+        }
+
+        return parent::update($attributes, $options);
+    }
+}

--- a/tests/Feature/Traits/SafeSaveTest.php
+++ b/tests/Feature/Traits/SafeSaveTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use Illuminate\Database\Eloquent\MassAssignmentException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\ValidatedInput;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Workbench\App\Models\Post;
+
+final class SafeSaveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function create_preserves_default_behavior_when_passed_array(): void
+    {
+        $this->expectException(MassAssignmentException::class);
+        $this->expectExceptionMessage('Add [title] to fillable property to allow mass assignment on [Workbench\App\Models\Post].');
+
+        Post::create(['title' => 'Thou shall not pass.']);
+    }
+
+    #[Test]
+    public function create_bypasses_mass_assignment_when_pass_validated_input(): void
+    {
+        $title = fake()->sentence();
+        $input = new ValidatedInput(['title' => $title]);
+
+        $post = Post::create($input);
+
+        $this->assertDatabaseHas($post);
+        $this->assertSame($title, $post->title);
+    }
+
+    #[Test]
+    public function update_preserves_default_behavior_when_passed_array(): void
+    {
+        $this->expectException(MassAssignmentException::class);
+        $this->expectExceptionMessage('Add [title] to fillable property to allow mass assignment on [Workbench\App\Models\Post].');
+
+        $post = Post::factory()->create();
+        $post->update(['title' => 'Thou shall not pass.']);
+    }
+
+    #[Test]
+    public function update_bypasses_mass_assignment_when_pass_validated_input(): void
+    {
+        $post = Post::factory()->create();
+
+        $title = fake()->sentence();
+        $input = new ValidatedInput(['title' => $title]);
+
+        $post->update($input);
+
+        $this->assertDatabaseHas($post);
+        $this->assertSame($title, $post->title);
+    }
+}

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use JMac\Additions\Traits\FindBy;
+use JMac\Additions\Traits\SafeSave;
 use Workbench\Database\Factories\PostFactory;
 
 #[UseFactory(PostFactory::class)]
 class Post extends Model
 {
-    use FindBy, HasFactory;
+    use FindBy, HasFactory, SafeSave;
 }


### PR DESCRIPTION
This introduces a `SafeSave` trait you may add to your Eloquent models to save data directly from "safe" input without doing the _fillable/guarded dance_.

More technically, you may `create` or `update` an Eloquent model from `ValidatedInput` without triggering a `MassAssignment` exception.

Let's review the following example which saves a `User` model within a resourceful `update` action:

```php
public function update(UserUpdateRequest $request, User $user)
{
     $user->update($request->safe());

     return redirect('user.show', $user);
}
```

The `$user->update()` method is passed a `ValidatedInput` object acquired from calling `safe()` on a `FormRequest` object. This data has been pre-validated, and as such is considered ready to save to the database.

Instead of casting the form request object to an `array`, and ensuring its corresponding keys are set in the `$fillable` property of the `User` (or its unguarded), we may pass `ValidatedInput` object directly and the `SafeSave` trait will "force fill" the data before calling `update`.

The same behavior is available for creation. For example:

```php
public function store(UserCreateRequest $request)
{
     $user = User::create($request->safe());

     return redirect('user.show', $user);
}
```