### PR TITLE
Introduce `WithFallback` trait to streamline policies

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,5 +20,6 @@
     <php>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="APP_KEY" value="base64:v56vtyxpw8mjNbfpfPWCawbrWHyBfy/NStRl2lq1cR8="/>
     </php>
 </phpunit>

--- a/src/Traits/WithFallback.php
+++ b/src/Traits/WithFallback.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JMac\Additions\Traits;
+
+trait WithFallback
+{
+    // Gate::update(User $user, Post $post)
+    // $name = 'update'
+    // $arguments = [$user, $post]
+
+
+    public function __call($name, $arguments)
+    {
+        if (!method_exists($this, 'fallback')) {
+            throw new \RuntimeException('You must define a fallback method when using the WithFallback trait');
+        }
+
+        // TODO: determine "shifting" arguments to `fallback`
+        // use cases:
+        //   - "resourceful" methods with user and model
+        //   - "resourceful" methods without model
+        //   - with additional arguments
+        //   - non-"resourceful" methods with additional arguments
+        dump($arguments);
+
+        return $this->fallback($name, $user, $model, ...$arguments);
+    }
+}

--- a/src/Traits/WithFallback.php
+++ b/src/Traits/WithFallback.php
@@ -2,27 +2,27 @@
 
 namespace JMac\Additions\Traits;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
 trait WithFallback
 {
-    // Gate::update(User $user, Post $post)
-    // $name = 'update'
-    // $arguments = [$user, $post]
-
-
     public function __call($name, $arguments)
     {
-        if (!method_exists($this, 'fallback')) {
+        if (! method_exists($this, 'fallback')) {
             throw new \RuntimeException('You must define a fallback method when using the WithFallback trait');
         }
 
-        // TODO: determine "shifting" arguments to `fallback`
-        // use cases:
-        //   - "resourceful" methods with user and model
-        //   - "resourceful" methods without model
-        //   - with additional arguments
-        //   - non-"resourceful" methods with additional arguments
-        dump($arguments);
+        $name = Str::snake($name, '-');
+        $user = array_shift($arguments);
+        $model = null;
 
-        return $this->fallback($name, $user, $model, ...$arguments);
+        if (isset($arguments[0])
+            && $arguments[0] instanceof Model
+            && str_starts_with(class_basename(self::class), class_basename($arguments[0]::class))) {
+            $model = array_shift($arguments);
+        }
+
+        return $this->fallback($name, $user, $model, $arguments);
     }
 }

--- a/tests/Feature/Traits/WithFallbackTest.php
+++ b/tests/Feature/Traits/WithFallbackTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use JMac\Additions\Traits\WithFallback;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Workbench\App\Models\Post;
+use Workbench\App\Models\User;
+use Workbench\App\Policies\PostPolicy;
+use Workbench\App\Policies\TestPolicy;
+
+final class WithFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_uses_the_trait(): void
+    {
+        $this->assertContains(WithFallback::class, class_uses(PostPolicy::class));
+    }
+
+    #[Test]
+    public function it_throws_exception_when_fallback_method_is_missing(): void
+    {
+        Gate::define('no-fallback', [TestPolicy::class, 'noFallback']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You must define a fallback method when using the WithFallback trait');
+
+        $user = User::factory()->create();
+
+        $this->withoutExceptionHandling();
+
+        $this->actingAs($user)->get(route('posts.no-fallback'));
+    }
+
+    #[Test]
+    public function it_fails_by_default(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('posts.index'));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_passed_the_snake_case_ability_name(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('posts.ability'));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_passes_the_authenticated_user(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'test@pass.me',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('posts.user'));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_fails_when_passed_user_when_unexpected_value(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('posts.user'));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_works_without_model(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.modelless'));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_passes_model(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create([
+            'title' => 'I Passed!',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.model', $post));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_fails_model_when_unexpected_value(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.model', $post));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_passes_arguments(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create([
+            'title' => 'I Passed!',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.arguments', $post));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_fails_arguments_when_unexpected_value(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.arguments', $post));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_passes_arguments_with_other_model(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create([
+            'email' => 'test@pass.me',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.other', $other));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_fails_arguments_with_other_model_when_unexpected_value(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.other', $other));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_still_uses_explicit_method(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.explicit', ['pass' => true]));
+
+        $response->assertOk();
+
+        $response = $this->actingAs($user)
+            ->get(route('posts.explicit', ['pass' => false]));
+
+        $response->assertForbidden();
+    }
+}

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Workbench\App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Workbench\App\Models\Post;
+use Workbench\App\Models\User;
+
+class PostController
+{
+    public function index()
+    {
+        Gate::authorize('viewAny', Post::class);
+    }
+
+    public function ability()
+    {
+        Gate::authorize('passAbility', Post::class);
+    }
+
+    public function user()
+    {
+        Gate::authorize('user', Post::class);
+    }
+
+    public function show(Post $post)
+    {
+        Gate::authorize('view', $post);
+    }
+
+    public function modelless()
+    {
+        Gate::authorize('modelless', Post::class);
+    }
+
+    public function arguments(Post $post)
+    {
+        Gate::authorize('arguments', [$post, true]);
+    }
+
+    public function other(User $user)
+    {
+        Gate::authorize('other', [Post::class, $user, true]);
+    }
+
+    public function explicit(Request $request)
+    {
+        Gate::authorize('explicit-ability', [Post::class, null, $request->boolean('pass')]);
+    }
+
+    public function noFallback()
+    {
+        Gate::authorize('no-fallback');
+    }
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -3,10 +3,13 @@
 namespace Workbench\App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Workbench\Database\Factories\UserFactory;
 
+#[UseFactory(UserFactory::class)]
 class User extends Authenticatable
 {
     use HasFactory, Notifiable;

--- a/workbench/app/Policies/PoTestPolicy.php
+++ b/workbench/app/Policies/PoTestPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Workbench\App\Policies;
+
+class PoTestPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/workbench/app/Policies/PostPolicy.php
+++ b/workbench/app/Policies/PostPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Workbench\App\Policies;
+
+use JMac\Additions\Traits\WithFallback;
+use Workbench\App\Models\Post;
+use Workbench\App\Models\User;
+
+class PostPolicy
+{
+    use WithFallback;
+
+    public function explicitAbility(User $user, ?Post $post, $pass): bool
+    {
+        return isset($pass) && $pass;
+    }
+
+    public function fallback($name, $user, $model, $arguments): ?bool
+    {
+        if ($name === 'pass-ability' && isset($user) && empty($model) && empty($arguments)) {
+            return true;
+        } elseif ($name === 'user') {
+            return $user?->email === 'test@pass.me';
+        } elseif ($name === 'modelless' && empty($model) && empty($arguments)) {
+            return true;
+        } elseif ($name === 'view') {
+            return $model?->title === 'I Passed!';
+        } elseif ($name === 'arguments') {
+            return $model?->title === 'I Passed!' && count($arguments) === 1 && $arguments[0];
+        } elseif ($name === 'other') {
+            return is_null($model) && count($arguments) === 2 && $arguments[0]->email === 'test@pass.me' && $arguments[1];
+        }
+
+        return false;
+    }
+}

--- a/workbench/app/Policies/TestPolicy.php
+++ b/workbench/app/Policies/TestPolicy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Workbench\App\Policies;
+
+use JMac\Additions\Traits\WithFallback;
+
+class TestPolicy
+{
+    use WithFallback;
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -5,3 +5,13 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('posts', [\Workbench\App\Http\Controllers\PostController::class, 'index'])->name('posts.index');
+Route::get('posts/ability', [\Workbench\App\Http\Controllers\PostController::class, 'ability'])->name('posts.ability');
+Route::get('posts/user', [\Workbench\App\Http\Controllers\PostController::class, 'user'])->name('posts.user');
+Route::get('posts/modelless', [\Workbench\App\Http\Controllers\PostController::class, 'modelless'])->name('posts.modelless');
+Route::get('posts/model/{post}', [\Workbench\App\Http\Controllers\PostController::class, 'show'])->name('posts.model');
+Route::get('posts/arguments/{post}', [\Workbench\App\Http\Controllers\PostController::class, 'arguments'])->name('posts.arguments');
+Route::get('posts/other/{user}', [\Workbench\App\Http\Controllers\PostController::class, 'other'])->name('posts.other');
+Route::get('posts/explicit', [\Workbench\App\Http\Controllers\PostController::class, 'explicit'])->name('posts.explicit');
+Route::get('posts/no-fallback', [\Workbench\App\Http\Controllers\PostController::class, 'noFallback'])->name('posts.no-fallback');


### PR DESCRIPTION
This introduces a `WithFallback` trait you may add to your model policies to streamline the repeated logic often found within these classes.

Consider the following snippet within a standard `PostPolicy` class:

```php
  public function update(User $user, Post $post): bool
  {
      return $user->id === $post->user_id;
  }

  public function delete(User $user, Post $post): bool
  {
      return $user->id === $post->user_id;
  }
```

Leveraging the `WithFallback` trait would allow you to define a single `fallback` method to condense this repeated logic.

```php
public function fallback(string $ability, User $user, ?Post $post, array $arguments): bool
{
      return $user->id === $post?->user_id;
}
```

Of course, the logic within this `fallback` method may be tightened and expanded based on the `$ability` being checked.

Nonetheless for model based policies, using `WithFallback` would still only be a single method containing a few lines of code instead of several methods.